### PR TITLE
fix: 修复发布帖子页面底部留白或遮挡和软键盘遮挡问题

### DIFF
--- a/src/pages/hole/post/BottomActions.tsx
+++ b/src/pages/hole/post/BottomActions.tsx
@@ -16,7 +16,6 @@ import { EmojiIcon } from '@/components/icon'
 import { Badges } from '@/components/Badges'
 import { EmojiArea } from '@/components/emoji/EmojiArea'
 import { HolePostBilibili } from '@/pages/hole/post/HolePostBilibili'
-import { PostCategorySelector } from '@/pages/hole/post/PostCategorySelector'
 import { useImagePicker } from '@/shared/hooks/useImagePicker'
 import { Categories } from '@/shared/constants/category'
 import { useImmer } from 'use-immer'
@@ -103,10 +102,7 @@ export function BottomActions() {
           </View>
         </View>
       </View>
-
-      <View className={'min-h-[120px]'}>
-        <EmojiArea onEmojiSelect={onEmojiSelect} expandArea={expand} />
-      </View>
+      <EmojiArea onEmojiSelect={onEmojiSelect} expandArea={expand} />
     </View>
   )
 }

--- a/src/pages/hole/post/Form.tsx
+++ b/src/pages/hole/post/Form.tsx
@@ -17,7 +17,7 @@ export function HolePostForm() {
   } = useHolePostContext()
 
   return (
-    <View className={'space-y-2 py-2 min-h-[50vh]'}>
+    <View className={'space-y-2 py-2 flex-1'}>
       <View className={'border-b-[1px] border-b-black/5'}>
         <NativeInput
           name={'title'}

--- a/src/pages/hole/post/body.tsx
+++ b/src/pages/hole/post/body.tsx
@@ -8,22 +8,20 @@ import { App } from '@/shared/utils/App'
 
 export function HolePostBody() {
   return (
-    <View className={'flex-1 justify-between'}>
+    <KeyboardAvoidingView
+      className={'flex-1 '}
+      behavior={App.keyboardAvoidingBehavior}
+    >
       <View className={'flex-1'}>
         <PostLeaveDialog />
-        <View className={'px-2'}>
+        <View className={'px-2 flex-1'}>
           <View>
             <HolePostHeader />
           </View>
           <HolePostForm />
         </View>
       </View>
-      <KeyboardAvoidingView
-        className={''}
-        behavior={App.keyboardAvoidingBehavior}
-      >
-        <BottomActions />
-      </KeyboardAvoidingView>
-    </View>
+      <BottomActions />
+    </KeyboardAvoidingView>
   )
 }

--- a/src/pages/hole/post/post.tsx
+++ b/src/pages/hole/post/post.tsx
@@ -9,12 +9,14 @@ export function HolePost() {
   const theme = useTheme()
 
   return (
-    <SafeAreaView className={'flex-1 bg-white'} edges={['bottom', 'top']}>
-      <HolePostContextProvider>
-        <View className={'h-screen'}>
-          <HolePostBody />
-        </View>
-      </HolePostContextProvider>
+    <SafeAreaView className={'flex-1 bg-white'} edges={['top']}>
+      <SafeAreaView className={'flex-1 bg-white'} edges={['bottom']}>
+        <HolePostContextProvider>
+          <View className={'flex-1'}>
+            <HolePostBody />
+          </View>
+        </HolePostContextProvider>
+      </SafeAreaView>
     </SafeAreaView>
   )
 }


### PR DESCRIPTION
- 解决了全面屏手势下底部 emoji 选择区域被遮挡的问题。
- 扩展 KeyboardAvoidingView 到整个页面，现在软键盘不会遮挡 BottomActions。
- 将正文输入的大小改为 flex, 防止在弹出软键盘时与 BottomActions 重叠。

注意：这些修改在 iOS 上的效果尚未测试。